### PR TITLE
Fixed Error for ":app:compileDebugJavaWithJavac"

### DIFF
--- a/android/app/src/main/java/com/demoapp/MainActivity.java
+++ b/android/app/src/main/java/com/demoapp/MainActivity.java
@@ -29,7 +29,7 @@ public class MainActivity extends Activity implements DefaultHardwareBackBtnHand
                 .setBundleAssetName("index.android.bundle")
                 .setJSMainModuleName("index.android")
                 .addPackage(new MainReactPackage())
-                .addPackage(new StatusBarPackage(this))
+                .addPackage(new StatusBarPackage())
                 .addPackage(new RCTSplashScreenPackage(this))
                 .setUseDeveloperSupport(BuildConfig.DEBUG)
                 .setInitialLifecycleState(LifecycleState.RESUMED)


### PR DESCRIPTION
When trying to run "react-native run-android", was giving the error:

 "error: constructor StatusBarPackage in class StatusBarPackage cannot be applied to given types;
                .addPackage(new StatusBarPackage(this))
                            ^
  required: no arguments
  found: MainActivity
  reason: actual and formal argument lists differ in length
1 error
:app:compileDebugJavaWithJavac FAILED

FAILURE: Build failed with an exception.
- What went wrong:
  Execution failed for task ':app:compileDebugJavaWithJavac'.
  > Compilation failed; see the compiler error output for details."

Code Changes:

Changed .addPackage(new StatusBarPackage(this)) to .addPackage(new StatusBarPackage())
