### PR TITLE
Include missing parameter for constructor

### DIFF
--- a/android/app/src/main/java/com/demoapp/MainActivity.java
+++ b/android/app/src/main/java/com/demoapp/MainActivity.java
@@ -30,7 +30,7 @@ public class MainActivity extends Activity implements DefaultHardwareBackBtnHand
                 .setJSMainModuleName("index.android")
                 .addPackage(new MainReactPackage())
                 .addPackage(new StatusBarPackage())
-                .addPackage(new RCTSplashScreenPackage(this))
+                .addPackage(new RCTSplashScreenPackage(this, true))
                 .setUseDeveloperSupport(BuildConfig.DEBUG)
                 .setInitialLifecycleState(LifecycleState.RESUMED)
                 .build();


### PR DESCRIPTION
This is the constructor. 
```
    public RCTSplashScreenPackage(Activity activity, boolean translucent) {
        super();
        this.activity = activity;
        this.translucent = translucent;
    }
```

react-native run-android was failing because of that.